### PR TITLE
Fix bug where it tried to do a readFileSync on dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ const createDirIfNotExist = to => {
 const copy = from => {
   const to = findTarget(from);
   createDirIfNotExist(to);
+  const stats = fs.statSync(from);
+  if (stats.isDirectory()) {
+    return;
+  }
   fs.writeFileSync(to, fs.readFileSync(from));
   console.log('[COPY]'.yellow, from, 'to'.yellow, to);
 };


### PR DESCRIPTION
This happened when I did something like `copy-and-watch lib/js/reason src/js/reason`. Then it threw this error

```
fs.js:682
[1]   var r = binding.read(fd, buffer, offset, length, position);
[1]                   ^
[1]
[1] Error: EISDIR: illegal operation on a directory, read
[1]     at Object.fs.readSync (fs.js:682:19)
[1]     at tryReadSync (fs.js:480:20)
[1]     at Object.fs.readFileSync (fs.js:517:19)
[1]     at FSWatcher.copy (/Users/arnarthorsveinsson/wowair/monorepo/node_modules/copy-and-watch/index.js:59:27)
[1]     at emitOne (events.js:96:13)
[1]     at FSWatcher.emit (events.js:191:7)
[1]     at FSWatcher.<anonymous> (/Users/arnarthorsveinsson/wowair/monorepo/node_modules/chokidar/index.js:196:15)
[1]     at FSWatcher._emit (/Users/arnarthorsveinsson/wowair/monorepo/node_modules/chokidar/index.js:238:5)
[1]     at FSWatcher.<anonymous> (/Users/arnarthorsveinsson/wowair/monorepo/node_modules/chokidar/lib/fsevents-handler.js:204:14)
[1]     at addOrChange (/Users/arnarthorsveinsson/wowair/monorepo/node_modules/chokidar/lib/fsevents-handler.js:210:7)
```