### PR TITLE
Added support for `—skip-initial-copy` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ copy-and-watch [options] <sources> <target>
 options:
   --watch - enable file watcher
   --clean - clean target folder on start
+  --skip-initial-copy - skip copying files initially, only copy if they change. Must be used with `--watch` argument.
 ```
 
 ### In your `package.json`
@@ -42,4 +43,5 @@ You may have some build script in your package.json involving mirroring folders 
 ## Changelog
 
 ##### 0.1.2
+
 - Fixed copy on dir bug (by arnarthor)


### PR DESCRIPTION
Added support for `—skip-initial-copy` argument. It is meant to be used with `--watch`. 

When enabled, it'll start watching files without copying them initially and only copy them when they have been changed.

Useful when we we build/copy everything initially and then concurrently run multiple watchers (maybe with https://www.npmjs.com/package/concurrently). This will help skip the second unnecessary copying.