### PR TITLE
Check file existence before removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,8 +68,12 @@ const copy = from => {
 };
 const remove = from => {
   const to = findTarget(from);
-  fs.unlinkSync(to);
-  console.log('[DELETE]'.yellow, to);
+  if(fs.existsSync(to)) {
+    fs.unlinkSync(to);
+    console.log('[DELETE]'.yellow, to);
+  }else{
+    console.log('[DELETE FAILED]'.yellow, to);
+  }  
 };
 const rimraf = dir => {
   if (fs.existsSync(dir)) {


### PR DESCRIPTION
If we attempt to unlinkSync the file, and it doesn't exist, the program fails. It shouldn't break. If the file is gone then its gone, over, there no need for the exception. The exception breaks the CLI execution.